### PR TITLE
Pin neo4j-python-driver to 1.1

### DIFF
--- a/norduniclient/contextmanager.py
+++ b/norduniclient/contextmanager.py
@@ -19,9 +19,9 @@ class Neo4jDBSessionManager:
     Neo4jDBSessionManager.transaction()
     """
 
-    def __init__(self, uri, username=None, password=None, encrypted=True):
+    def __init__(self, uri, username=None, password=None, encrypted=True, max_pool_size=50):
         self.uri = uri
-        self.driver = get_db_driver(uri, username, password, encrypted)
+        self.driver = get_db_driver(uri, username, password, encrypted, max_pool_size)
 
     @contextmanager
     def _session(self):

--- a/norduniclient/contextmanager.py
+++ b/norduniclient/contextmanager.py
@@ -14,17 +14,9 @@ class Neo4jDBSessionManager:
     Every new connection is a transaction. To minimize new connection overhead for many reads we try to reuse a single
     connection. If this seem like a bad idea some kind of connection pool might work better.
 
-    Neo4jDBSessionManager.read()
-    When using with Neo4jDBSessionManager.read(): we will always rollback the transaction. All exceptions will be
-    thrown.
-
-    Neo4jDBSessionManager.write()
-    When using with Neo4jDBSessionManager.write() we will always commit the transaction except when we see an
-    exception. If we get an exception we will rollback the transaction and throw the exception.
+    Neo4jDBSessionManager.session()
 
     Neo4jDBSessionManager.transaction()
-    When we don't want to share a connection (transaction context) we can set up a new connection which will work
-    just as the write context manager above but with it's own connection.
     """
 
     def __init__(self, uri, username=None, password=None, encrypted=True):

--- a/norduniclient/tests/test_core.py
+++ b/norduniclient/tests/test_core.py
@@ -2,7 +2,10 @@
 
 from __future__ import absolute_import
 
-from neo4j.exceptions import ConstraintError
+try:
+    from neo4j.exceptions import ConstraintError
+except ImportError:
+    from neo4j.v1.api import CypherError as ConstraintError  # Backwards compatability with version <1.2
 
 from norduniclient.testing import Neo4jTestCase
 from norduniclient import core

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 
-version = '1.0.14'
+version = '1.0.15b0'
 
 requires = [
-    'neo4j-driver>=1.4.0,<1.5.0',
+    'neo4j-driver<1.2.0',
     'six>=1.10.0',
 ]
 


### PR DESCRIPTION
Seems we have problems with results from closed sessions spill over to next session.